### PR TITLE
Add a script to compare test releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+releases/*

--- a/compare-releases.py
+++ b/compare-releases.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import os, sys, argparse, tarfile, pathlib
+
+def files_in_tgz(f):
+    with tarfile.open(f) as tgz:
+        for n in tgz.getnames():
+            yield os.path.normpath(n)
+
+def test_set_in_tgz(f):
+    return set(files_in_tgz(f))
+
+def show_testset_difference(opts, set, previous, current):
+    size = len(current)
+    removed, added = (previous - current, current - previous)
+    print(f"{set} has {size} test files, with {len(added)} added to and {len(removed)} removed from the previous release.")
+    if opts.verbose:
+        for t in removed: print(f"  removed {t}")
+        for t in added: print(f"  added {t}")
+
+def show_release_difference(opts, testsets):
+    for set, previous, current in testsets:
+        show_testset_difference(opts, set, previous, current)
+
+def get_testsets(prev_release_dir, cur_release_dir):
+    testset_names = ["riscv-tests"] + [f"riscv-vector-tests-v{vlen}x{xlen}" for vlen in [128, 256, 512] for xlen in [32, 64]]
+    testset_filenames = [name + ".tar.gz" for name in testset_names]
+    return [(name,
+             test_set_in_tgz(os.path.join(prev_release_dir, filename)),
+             test_set_in_tgz(os.path.join(cur_release_dir, filename)))
+            for (name, filename) in zip(testset_names, testset_filenames)]
+
+def make_cli_parser():
+    parser = argparse.ArgumentParser(description="Compare testsets from two releases")
+    parser.add_argument('-p', '--previous', type=pathlib.Path, required=True, help="directory containing testsets from previous release")
+    parser.add_argument('-c', '--current', type=pathlib.Path, required=True, help="directory containing testsets from current release")
+    parser.add_argument('-v', '--verbose', action='store_const', const=True, help="show files added or removed")
+    return parser
+
+if __name__ == "__main__":
+    parser = make_cli_parser()
+    cliopts = sys.argv[1:]
+    if len(cliopts) == 0:
+        parser.print_help()
+        sys.exit(0)
+    opts = parser.parse_args(cliopts)
+    testsets = get_testsets(opts.previous, opts.current)
+    show_release_difference(opts, testsets)

--- a/justfile
+++ b/justfile
@@ -8,17 +8,18 @@ SPIKE_COMMIT_HASH := "f51df5d3955a27602a872eaf01492177513baf6f"
 TOOLCHAIN_URL := "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/" + TOOLCHAIN_RELEASE_DATE + "/riscv64-elf-ubuntu-22.04-gcc.tar.xz"
 RISCV_TESTS_ARCHIVE := "riscv-tests.tar.gz"
 VECTOR_TESTS_ARCHIVE_PREFIX := "riscv-vector-tests-"
+RELEASE_DOWNLOAD_URL := "https://github.com/riscv-software-src/sail-riscv-tests/releases/download"
 
 default:
-	@just --unstable --list
+    @just --unstable --list
 
 ### Version recipes
 
 show-spike-hash:
-	@echo {{SPIKE_COMMIT_HASH}}
+    @echo {{SPIKE_COMMIT_HASH}}
 
 show-toolchain-release:
-	@echo {{TOOLCHAIN_RELEASE_DATE}}
+    @echo {{TOOLCHAIN_RELEASE_DATE}}
 
 ### Toolchain recipe
 
@@ -49,13 +50,13 @@ build-riscv-tests prefix=INSTALL_PREFIX: (prepare-riscv-tests prefix)
 
 [working-directory: 'riscv-tests']
 tar-riscv-tests prefix=INSTALL_PREFIX: (build-riscv-tests prefix)
-    tar -cvzf ../{{RISCV_TESTS_ARCHIVE}} --exclude='*.dump' -C {{prefix}}/riscv-tests/share/riscv-tests/isa .
+    tar -cvzf ../{{RISCV_TESTS_ARCHIVE}} --exclude='*.dump' --exclude ".gitignore" --exclude "Makefile" -C {{prefix}}/riscv-tests/share/riscv-tests/isa .
 
 riscv-tests-tgz prefix=INSTALL_PREFIX: (prepare-riscv-tests prefix) (build-riscv-tests prefix) (tar-riscv-tests prefix)
 
 [working-directory: 'riscv-tests']
 clean-riscv-tests:
-	make clean
+    make clean
 
 ### Spike recipes
 
@@ -99,9 +100,31 @@ vector-tests-tgz VLEN XLEN prefix=INSTALL_PREFIX: (build-vector-tests VLEN XLEN 
 clean-vector-tests:
     make clean
 
+### Release management
+
+[script("/usr/bin/bash")]
+download-release release:
+    set -eux
+    mkdir -p releases/{{release}}
+    if [ ! -f releases/{{release}}/{{RISCV_TESTS_ARCHIVE}} ]; then
+      wget -O releases/{{release}}/{{RISCV_TESTS_ARCHIVE}} {{RELEASE_DOWNLOAD_URL}}/{{release}}/{{RISCV_TESTS_ARCHIVE}}
+    fi
+    for vlen in 128 256 512; do
+      for xlen in 32 64; do
+        if [ ! -f releases/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz ]; then
+          wget -O releases/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz {{RELEASE_DOWNLOAD_URL}}/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz
+        fi
+      done
+    done
+
+# This provides only a summary. For detailed differences, run `compare-releases.py` directly with `-v`.
+[doc]
+compare-releases previous current: (download-release previous) (download-release current)
+    ./compare-releases.py -p releases/{{previous}} -c releases/{{current}}
+
 ### Miscellaneous
 
 show-default-install-prefix:
-	@echo {{INSTALL_PREFIX}}
+    @echo {{INSTALL_PREFIX}}
 
 clean: clean-riscv-tests clean-vector-tests clean-spike


### PR DESCRIPTION
Add a script to compare test releases.

This would be useful in generating release notes and in PRs that update the test suite in `sail-riscv`.

Also ignore some accidentally included but harmless files in `riscv-tests` and delete tabs in justfile.