### PR TITLE
Update vector test combinations.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,9 +113,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        VLEN: [128, 256, 512]
+        VLEN: [64, 128, 256]
         # For now, ELEN can't be freely choosen and needs to match XLEN
         XLEN: [32, 64]
+        # Omit the 512/32 combination because it takes around 6 hours to build
+        # often exceeding the Github CI limit of 6 hours.
+        include:
+          - VLEN: 512
+            XLEN: 64
 
     steps:
       - name: Free Disk Space

--- a/compare-releases.py
+++ b/compare-releases.py
@@ -31,7 +31,8 @@ def show_release_difference(opts, testsets):
         show_testset_difference(opts, set, previous, current)
 
 def get_testsets(prev_release_dir, cur_release_dir):
-    testset_names = ["riscv-tests", "riscv-arch-tests"] + [f"riscv-vector-tests-v{vlen}x{xlen}" for vlen in [128, 256, 512] for xlen in [32, 64]]
+    combos = [(vlen, xlen) for vlen in [64, 128, 256, 512] for xlen in [32, 64]]
+    testset_names = ["riscv-tests", "riscv-arch-tests"] + [f"riscv-vector-tests-v{vlen}x{xlen}" for (vlen, xlen) in combos]
     testset_filenames = [name + ".tar.gz" for name in testset_names]
     return [(name,
              os.path.join(prev_release_dir, filename),

--- a/justfile
+++ b/justfile
@@ -111,11 +111,12 @@ vector-tests-tgz VLEN XLEN prefix=INSTALL_PREFIX: (build-vector-tests VLEN XLEN 
 [script("/usr/bin/bash")]
 all-vector-tests-tgz prefix=INSTALL_PREFIX:
     set -eux
-    for vlen in 128 256 512; do
+    for vlen in 64 128 256; do
       for xlen in 32 64; do
         just --unstable vector-tests-tgz ${vlen} ${xlen}
       done
     done
+    just --unstable vector-tests-tgz 512 64
 
 # Without a specified VLEN and XLEN, the clean target only cleans the build
 # for the default VLEN/XLEN.  This makes sure all the combinations used
@@ -124,7 +125,7 @@ all-vector-tests-tgz prefix=INSTALL_PREFIX:
 [working-directory: 'riscv-vector-tests']
 [script("/usr/bin/bash")]
 clean-vector-tests:
-    for vlen in 128 256 512; do
+    for vlen in 64 128 256 512; do
       for xlen in 32 64; do
         make VLEN=${vlen} XLEN=${xlen} clean
       done
@@ -167,13 +168,18 @@ download-release release:
     if [ ! -f releases/{{release}}/{{RISCV_TESTS_ARCHIVE}} ]; then
       wget -O releases/{{release}}/{{RISCV_TESTS_ARCHIVE}} {{RELEASE_DOWNLOAD_URL}}/{{release}}/{{RISCV_TESTS_ARCHIVE}}
     fi
-    for vlen in 128 256 512; do
+    for vlen in 64 128 256; do
       for xlen in 32 64; do
         if [ ! -f releases/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz ]; then
           wget -O releases/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz {{RELEASE_DOWNLOAD_URL}}/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz
         fi
       done
     done
+    vlen=512
+    xlen=64
+    if [ ! -f releases/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz ]; then
+      wget -O releases/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz {{RELEASE_DOWNLOAD_URL}}/{{release}}/{{VECTOR_TESTS_ARCHIVE_PREFIX}}v${vlen}x${xlen}.tar.gz
+    fi
 
 # This provides only a summary. For detailed differences, run `compare-releases.py` directly with `-v`.
 [doc]


### PR DESCRIPTION
This adds VLEN=64,ELEN={32,64} to the vector suite while removing VLEN=512,ELEN=32.

VLEN=64 is not included in the full Vector extension which requires VLEN>=128, and provides a new test combination.

The removed combination of (512,32) took around 6 hours and sometimes tripped over Github CI's max execution limit of 6 hours, causing unreliable builds.

Fixes #51.